### PR TITLE
v1.2: anchor video & better logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Always use the last two functions in `try..catch`, because they will throw with 
 
 `wb.getVideo(videoId)` - returns `isWatched` for a video ID; will return `false` if the video does not exist in the bitfield
 
+
+### serialized format
+
+`{lastVideoID}:{lastLength}:{serializedBuf}`

--- a/lib/bitfield8.js
+++ b/lib/bitfield8.js
@@ -26,6 +26,7 @@ BitField8.fromPacked = function(compressed, len) {
 BitField8.prototype.get = function(i) {
     var index = (i / 8) | 0
     var bit = i % 8
+    if (!this.values[index]) return false
     return (this.values[index] & (1 << bit)) !== 0
 }
 
@@ -35,6 +36,13 @@ BitField8.prototype.set = function(i, val) {
     var mask = 1 << bit
     if (val) this.values[index] |= mask
     else this.values[index] &= ~mask
+}
+
+BitField8.prototype.lastIndexOf = function(val) {
+	for (var i=this.length-1; i>=0; --i)
+		if (this.get(i) === val)
+			return i
+	return -1
 }
 
 BitField8.prototype.toPacked = function() {

--- a/lib/watchedBitfield.js
+++ b/lib/watchedBitfield.js
@@ -26,7 +26,7 @@ watchedBitfield.constructAndResize = function(serialized, videoIds) {
 
 	// serialized is formed by {id}:{len}:{serializedBuf}, but since {id} might contain : we have to pop gradually and then keep the rest
 	var components = serialized.split(':')
-	if (components.length < 3) throw 'invalid components length'
+	if (components.length < 3) throw new Error('invalid components length')
 
 	var serializedBuf = components.pop()
 	var lastLength = parseInt(components.pop(), 10)

--- a/lib/watchedBitfield.js
+++ b/lib/watchedBitfield.js
@@ -36,10 +36,9 @@ watchedBitfield.constructAndResize = function(serialized, videoIds) {
 	// in case of an previous empty array, this will be 0
 	var offset = (lastLength-1) - lastVideoIdx
 
-	// if offset < 0, it means we've unshifted videos, which is not allowed
 	// we can only shift from the beginning, or push to the back (moves in this <- direction)
-	var isResizedAndUnshiftable = lastVideoIdx === -1 || offset < 0
-	var isResizedAndShiftable = offset > 0
+	var isResizedAndUnshiftable = lastVideoIdx === -1
+	var isResizedAndShiftable = offset !== 0
 
 	if (isResizedAndUnshiftable || isResizedAndShiftable) {
 		// Resize the buffer
@@ -52,8 +51,10 @@ watchedBitfield.constructAndResize = function(serialized, videoIds) {
 
 		if (isResizedAndShiftable) {
 			var buf = BitField8.fromPacked(atob(serializedBuf), lastLength)
-			for (var i=offset; i!=buf.length; i++) {
-				resizedBuf.set(i-offset, buf.get(i))
+			for (var i=0; i<videoIds.length; i++) {
+				var idxInOld = i+offset
+				if (idxInOld >= 0 && idxInOld < buf.length)
+					resizedBuf.set(i, buf.get(idxInOld))
 			}
 			return resizedBuf
 		}

--- a/lib/watchedBitfield.js
+++ b/lib/watchedBitfield.js
@@ -22,42 +22,39 @@ watchedBitfield.constructAndResize = function(serialized, videoIds) {
 	// should we assert?
 	// we might also wanna assert that the bitfield.length for the returned wb is the same sa videoIds.length
 
-	// @TODO: move the logic to other functions
-
 	// serialized is formed by {id}:{len}:{serializedBuf}, but since {id} might contain : we have to pop gradually and then keep the rest
 	var components = serialized.split(':')
 	if (components.length < 3) throw new Error('invalid components length')
 
 	var serializedBuf = components.pop()
-	var lastLength = parseInt(components.pop(), 10)
-	var lastVideoId = components.join(':')
-	var lastVideoIdx = videoIds.indexOf(lastVideoId)
+	var anchorLength = parseInt(components.pop(), 10)
+	var anchorVideoId = components.join(':')
+	var anchorVideoIdx = videoIds.indexOf(anchorVideoId)
 
 	// in case of an previous empty array, this will be 0
-	var offset = (lastLength-1) - lastVideoIdx
+	var offset = (anchorLength-1) - anchorVideoIdx
 
-	// we can only shift from the beginning, or push to the back (moves in this <- direction)
-	var isResizedAndUnshiftable = lastVideoIdx === -1
-	var isResizedAndShiftable = offset !== 0
+	// We can shift the bitmap in any direction, as long as we can find the anchor video
+	var anchorNotFound = anchorVideoIdx === -1
+	var mustShift = offset !== 0
 
-	if (isResizedAndUnshiftable || isResizedAndShiftable) {
+	if (anchorNotFound || mustShift) {
 		// Resize the buffer
 		var resizedBuf = new watchedBitfield(new BitField8(videoIds.length), videoIds)
 
-		if (isResizedAndUnshiftable) {
+		if (anchorNotFound) {
 			// videoId could not be found, return a totally blank buf
 			return resizedBuf
 		}
 
-		if (isResizedAndShiftable) {
-			var buf = BitField8.fromPacked(atob(serializedBuf), lastLength)
-			for (var i=0; i<videoIds.length; i++) {
-				var idxInOld = i+offset
-				if (idxInOld >= 0 && idxInOld < buf.length)
-					resizedBuf.set(i, buf.get(idxInOld))
-			}
-			return resizedBuf
+		// rewrite the old buf into the new one, applying the offset 
+		var prevBuf = BitField8.fromPacked(atob(serializedBuf), anchorLength)
+		for (var i=0; i<videoIds.length; i++) {
+			var idxInOld = i+offset
+			if (idxInOld >= 0 && idxInOld < prevBuf.length)
+				resizedBuf.set(i, prevBuf.get(idxInOld))
 		}
+		return resizedBuf
 	}
 
 	var buf = BitField8.fromPacked(atob(serializedBuf), videoIds.length)
@@ -87,7 +84,11 @@ watchedBitfield.prototype.getVideo = function(videoId) {
 watchedBitfield.prototype.serialize = function() {
 	var packed = this.bitfield.toPacked()
 	var packedStr = String.fromCharCode.apply(null, packed)
-	return this.videoIds[this.videoIds.length-1]+':'+this.bitfield.length+':'+btoa(packedStr)
+	// set the anchor to the last watched video, rather than the last one
+	// that way, we ensure we retain the bitmap, even if some items are removed from the end (upcoming videos)
+	var lastIdx = Math.max(0, this.bitfield.lastIndexOf(true))
+	//var lastIdx = this.videoIds.length - 1
+	return this.videoIds[lastIdx]+':'+(lastIdx + 1)+':'+btoa(packedStr)
 }
 
 module.exports = watchedBitfield

--- a/lib/watchedBitfield.js
+++ b/lib/watchedBitfield.js
@@ -50,9 +50,9 @@ watchedBitfield.constructAndResize = function(serialized, videoIds) {
 		// rewrite the old buf into the new one, applying the offset 
 		var prevBuf = BitField8.fromPacked(atob(serializedBuf), anchorLength)
 		for (var i=0; i<videoIds.length; i++) {
-			var idxInOld = i+offset
-			if (idxInOld >= 0 && idxInOld < prevBuf.length)
-				resizedBuf.set(i, prevBuf.get(idxInOld))
+			var idxInPrev = i+offset
+			if (idxInPrev >= 0 && idxInPrev < prevBuf.length)
+				resizedBuf.set(i, prevBuf.get(idxInPrev))
 		}
 		return resizedBuf
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stremio-watched-bitfield",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stremio-watched-bitfield",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A bitfield of watched episodes for a libraryItem",
   "main": "index.js",
   "scripts": {

--- a/test/watchedBitfield.js
+++ b/test/watchedBitfield.js
@@ -78,7 +78,20 @@ tape('construct and resize: append at the end, remove from the beginning', funct
 	var ids =      [ '1','2','3','4','5','6','7','8','9','a','b','c' ]
 
 	var idsChanged = ids.slice(2).concat([     'd', 'e', 'f', 'g'])
-	var bitArrayExpected = bitArray.slice(2).concat([0,   0,   0,   0]);
+	var bitArrayExpected = bitArray.slice(2).concat([0,   0,   0,   0])
+
+	testIsAsExpected(t, bitArray, ids, idsChanged, bitArrayExpected)
+
+	t.end()
+})
+
+tape('construct and resize: remove from the end, append to the beginning', function(t) {
+	// the last ID that won't be popped ('a') needs to be the last watched, so we can use it as an anchor
+	var bitArray = [  0 , 0 , 0 , 0 , 0 , 0 , 1 , 1 , 1 , 1 , 0 , 0  ]
+	var ids =      [ '1','2','3','4','5','6','7','8','9','a','b','c' ]
+
+	var idsChanged =       ['d', 'e'].concat(ids).slice(0, ids.length)
+	var bitArrayExpected = [ 0,   0 ].concat(bitArray).slice(0, bitArray.length)
 
 	testIsAsExpected(t, bitArray, ids, idsChanged, bitArrayExpected)
 
@@ -133,7 +146,8 @@ function testIsAsExpected(t, bitArray, ids, idsChanged, arrExpected) {
 	t.equal(wb.bitfield.length, arrExpected.length)
 	t.deepEquals(bfToArr(wb.bitfield), arrExpected, 'bit array is as expected')
 
-	t.ok(wb.serialize().startsWith(idsChanged[idsChanged.length-1]))
+	var lastWatchedIdx = Math.max(0, wb.bitfield.lastIndexOf(true))
+	t.ok(wb.serialize().startsWith(idsChanged[lastWatchedIdx]))
 }
 
 function bfToArr(bf) {

--- a/test/watchedBitfield.js
+++ b/test/watchedBitfield.js
@@ -98,6 +98,18 @@ tape('construct and resize: remove from the end, append to the beginning', funct
 	t.end()
 })
 
+tape('construct and resize: append to the beginning', function(t) {
+	var bitArray = [  0 , 0 , 0 , 0 , 0 , 0 , 1 , 1 , 1 , 1 , 0 , 1  ]
+	var ids =      [ '1','2','3','4','5','6','7','8','9','a','b','c' ]
+
+	var idsChanged =       ['d', 'e'].concat(ids)
+	var bitArrayExpected = [ 0,   0 ].concat(bitArray)
+
+	testIsAsExpected(t, bitArray, ids, idsChanged, bitArrayExpected)
+
+	t.end()
+})
+
 tape('construct and resize: totally different set of IDs', function(t) {
 	var bitArray = [  0 , 0 , 0 , 0 , 0 , 0 , 1 , 1 , 1 , 1 , 1 , 1  ]
 	var ids =      [ '1','2','3','4','5','6','7','8','9','a','b','c' ]


### PR DESCRIPTION
contains two significant improvements:

- "last" video renamed to "anchor" video; this is so cause we use it to shift/unshift the bitmap depending on it's position in the new videos array
- allows shifting videos around the anchor video in both directions
- the anchor is set not to the last video, but to the last watched video, increasing the likelyhood of it being found, even if the last video was removed


----


**We need to update addon docs:** explain that `videos` order should be the stable